### PR TITLE
Use apk `--no-cache' instead of `--update'

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
 FROM alpine
 MAINTAINER Jessie Frazelle <jess@docker.com>
 
-RUN apk --update add \
+RUN apk --no-cache add \
 	ca-certificates \
 	curl \
 	tar \
 	py-pip \
-	&& rm -rf /var/cache/apk/* \
 	&& pip install s3cmd
 
 ENV HUGO_VERSION 0.14


### PR DESCRIPTION
This avoids the need to do `rm -rf /var/cache/apk`. Needs alpine ≥ 3.3.
See https://github.com/gliderlabs/docker-alpine/blob/f93486d/docs/usage.md#disabling-cache

Here's an example diff between running `apk --no-cache add tar` and `apk --update add tar`:

```
$ diff <(docker diff e1ce7fc8b230 | sort) <(docker diff 4f4bb52532e5 | sort)         
3a4,5
> A /var/cache/apk/APKINDEX.5a59b88b.tar.gz
> A /var/cache/apk/APKINDEX.7c1f02d6.tar.gz
16a19,21
> C /var
> C /var/cache
> C /var/cache/apk
```

Thanks so much, you rock! :smile: 
