### PR TITLE
to draw your attention for a typo

### DIFF
--- a/content/post/containers-security-and-echo-chambers.md
+++ b/content/post/containers-security-and-echo-chambers.md
@@ -76,7 +76,7 @@ various container runtimes as of two years ago.  Note the strong defaults in
 Docker. The paper also explains at length the defaults and would be a less
 biased version than me explaining myself.
 
-![defaults.png](/img/defaults.png)
+![defaults.png](/img/defaults.png) // TODO fix typo in that image
 
 ## Breaking Changes
 


### PR DESCRIPTION
I enjoy reading your blog post and would like to to draw your attention for a typo.
In the last row of the overview in the column `Security Feature` there is a typo `Root Interation`.  I guess, it should be Root Interaction. As I mentioned great blog post, thanks.