### PR TITLE
Add ref to PR adding rootless containers to runc

### DIFF
--- a/content/post/getting-towards-real-sandbox-containers.md
+++ b/content/post/getting-towards-real-sandbox-containers.md
@@ -51,6 +51,8 @@ spawned a
 [mailing list thread for implementing this in runc/libcontainer](https://groups.google.com/a/opencontainers.org/forum/#!topic/dev/yutVaSLcqWI).
 [Aleksa Sarai](https://github.com/cyphar) has started on a few patches and this might actually be a reality pretty soon!
 
+Update: it took almost a year, but this was [added to runc](https://github.com/opencontainers/runc/pull/774) in Mar 2017.
+
 #### Where does this put us in the "sandbox" landscape?
 
 With this implementation we get:


### PR DESCRIPTION
Since this blog post was originally published, support for rootless containers has been added to runc.

I actually originally learned about this from your ["Container Linux on the Desktop"](https://docs.google.com/presentation/d/17Hml1iFqdXElxOcrh9caQSC5px5mDgaS015Vhaz42ZY/edit#slide=id.p) presentation! Was reading other blog posts about sandboxes and thought this warranted an update.