### PR TITLE
`exit` instead of `return` in shell script

### DIFF
--- a/content/post/routing-traffic-through-tor-docker-container.md
+++ b/content/post/routing-traffic-through-tor-docker-container.md
@@ -51,7 +51,7 @@ Contain yourselves, I am about to throw down some sick iptables rules.
 # to run iptables commands you need to be root
 if [ "$EUID" -ne 0 ]; then
     echo "Please run as root."
-    return 1
+    exit 1
 fi
 
 ### set variables


### PR DESCRIPTION
From STDOUT:

Please run as root.
./testfoo.sh: line 8: return: can only `return' from a function or
sourced script